### PR TITLE
Click on document does not close the selectbox

### DIFF
--- a/js/SelectBox.js
+++ b/js/SelectBox.js
@@ -72,7 +72,7 @@
 
 		function init() {
 			// TODO: don't use userAgent matching to detect defaulting to device specific behavior
-			_useDefaultBehavior = navigator.hasOwnProperty('screenOrientation');
+			_useDefaultBehavior = navigator.userAgent.match(/iPad|iPhone|Android|IEMobile|BlackBerry/i) ? true : false;
 
 			if( _useDefaultBehavior ) {
 				cfg.selectbox.addClass("use-default");


### PR DESCRIPTION
Jquery version 1.10.4. Click on body does not close the select box.
The problem is here https://github.com/roblaplaca/jQuery-Custom-Selectbox/blob/master/js/SelectBox.js#L28
if element has not this parents, `$(e.target).parents(".customSelect").get(0)` equals `undefined` instead of `null`.
This is the most optimal solution i know. 
